### PR TITLE
Add "restart ssh" handler

### DIFF
--- a/gateway/roles/network/handlers/main.yml
+++ b/gateway/roles/network/handlers/main.yml
@@ -6,3 +6,5 @@
 - name: restart firewall
   service: name=firewall state=restarted
   service: name=firewall6 state=restarted
+- name: restart sshd
+  service: name=ssh state=restarted


### PR DESCRIPTION
The "network" role task to copy SSH secrets expects to run a handler to
restart sshd, which didn't exist.