### PR TITLE
Fix user groups on initial provision

### DIFF
--- a/gateway/gateway.yml
+++ b/gateway/gateway.yml
@@ -10,5 +10,5 @@
   - {role: doord, tags: doord}
   - {role: camera, tags: camera}
   - {role: monitor, tags: monitor}
-  - {role: user, tags: user}
   - {role: printer, tags: printer}
+  - {role: user, tags: user}


### PR DESCRIPTION
The "lpadmin" group that is created by cups during installation of printer stuff is required by the "users" role, so make sure printers are installed first