### PR TITLE
Resolv tail

### DIFF
--- a/gateway/config/resolv.conf.tail
+++ b/gateway/config/resolv.conf.tail
@@ -1,0 +1,1 @@
+nameserver 64.6.64.6

--- a/gateway/roles/network/tasks/main.yml
+++ b/gateway/roles/network/tasks/main.yml
@@ -17,6 +17,8 @@
   notify: restart bind
 - copy: src=config/default-bind dest=/etc/default/bind9 
   notify: restart bind
+- copy: src=config/resolv.conf.head
+  notify: restart resolvconf
 
 - apt: pkg=openvpn
 - copy: src=config/openvpn-www.conf dest=/etc/openvpn/

--- a/gateway/roles/network/tasks/main.yml
+++ b/gateway/roles/network/tasks/main.yml
@@ -17,7 +17,7 @@
   notify: restart bind
 - copy: src=config/default-bind dest=/etc/default/bind9 
   notify: restart bind
-- copy: src=config/resolv.conf.head
+- copy: src=config/resolv.conf.tail dest=/etc/resolvconf/resolv.conf.d/tail
   notify: restart resolvconf
 
 - apt: pkg=openvpn


### PR DESCRIPTION
resolvconf manages /etc/resolv.conf.

This PR adds verisign dns to the footer of resolv.conf which means that we can continue operation if bind gets in a mess.