### PR TITLE
[Useradmin] Change terminology from "keyholder" to "full member"

### DIFF
--- a/useradmin/README.md
+++ b/useradmin/README.md
@@ -1,0 +1,15 @@
+# Useradmin - basic member management tools
+
+Very basic member management tools. Interacts with the member database used by `doord`.
+
+Written in a weekend to provide some basic tools so the code quality isn't great.
+
+## Running in Docker
+
+A `Dockerfile` is provided which runs the application.
+
+A `docker-compose` file is also provided which can run the application and a MySQL database with a blank schema, which is far more useful for development.
+
+Run `docker-compose start` to start.
+
+Access on `localhost:80`.

--- a/useradmin/src/pages/addmember-form.php
+++ b/useradmin/src/pages/addmember-form.php
@@ -43,10 +43,10 @@ require_once('header.php');
         </div>
     </div>
     <div class="form-group">
-        <label for="keyholder" class="col-sm-2">24/7 access?</label>
+        <label for="keyholder" class="col-sm-2">Full member?</label>
         <div class="col-sm-10">
             <input type="checkbox" id="keyholder" />
-            <p class="help-block">People with 24/7 access can open the space and be there on their own.</p>
+            <p class="help-block">Full members have 24/7 access; provisional members can use the space when a full member is there.</p>
         </div>
     </div>
 
@@ -63,8 +63,6 @@ require_once('header.php');
             <button type="submit" class="btn btn-primary">Submit</button>
         </div>
     </div>
-    
-
 </form>
 
 <script type="text/javascript">

--- a/useradmin/src/pages/changepin-form.php
+++ b/useradmin/src/pages/changepin-form.php
@@ -4,7 +4,7 @@ $active = 'members';
 require_once('header.php');
 ?>
 <h1>Change PIN</h1>
-<p>If the member isn't a keyholder, this function won't be a huge amount of use.</p>
+<p>If the member has provisional membership, this function won't be a huge amount of use.</p>
 <form action="<?php echo Utils::base(); ?>/?action=changepin" method="POST" class="form-horizontal">
     <input type="hidden" name="card_id" value="<?php echo htmlspecialchars($_GET['card_id']); ?>" />
     <input type="hidden" name="user_id" value="<?php echo htmlspecialchars($_GET['user_id']); ?>" />

--- a/useradmin/src/pages/members.php
+++ b/useradmin/src/pages/members.php
@@ -14,7 +14,7 @@ $dbh = Utils::getPdo();
             <th>Full Name</th>
             <th>Email</th>
             <th>Member?</th>
-            <th>Keyholder?</th>
+            <th>Full member?</th>
             <th>Door access</th>
             <th>Payment ref</th>
         </tr>

--- a/useradmin/src/pages/viewmember.php
+++ b/useradmin/src/pages/viewmember.php
@@ -54,15 +54,15 @@ $devices = $deviceStmt->fetchAll();
     <dd><?php echo htmlspecialchars($person['paymentref']); ?></dd>
 </dl>
 
-<h2>24/7 access status</h2>
+<h2>Membership status</h2>
 <?php
 switch ($person['access']):
     case 'BOTH': ?>
-        <p>24/7 member</p>
+        <p>Full member (24/7 access)</p>
         <form action="<?php echo Utils::base(); ?>/?action=keyholder" method="post">
             <input type="hidden" name="id" value="<?php echo htmlspecialchars($person['id']); ?>" />
             <input type="hidden" name="access" value="NO" />
-            <button type="submit" class="btn btn-danger">Revoke keyholder status</button>
+            <button type="submit" class="btn btn-danger">Make provisional member</button>
         </form>
 <?php
         break;
@@ -71,22 +71,18 @@ switch ($person['access']):
         <p>Downstairs only (probably a Pedaller)</p>
         <form action="<?php echo Utils::base(); ?>/?action=keyholder" method="post">
             <input type="hidden" name="id" value="<?php echo htmlspecialchars($person['id']); ?>" />
-            <input type="hidden" name="access" value="BOTH" />
-            <?php if ($person['access'] === 'NO'): ?>
-                <button type="submit" class="btn btn-warning">Make keyholder</button>
-            <?php endif; ?>
+            <button type="submit" name="access" value="BOTH" class="btn btn-warning">Make full member</button>
+            <button type="submit" name="access" value="NO" class="btn btn-warning">Make provisional member</button>
         </form>
 <?php
         break;
 
     case 'NO': ?>
-        <p>No 24/7 access</p>
+        <p>Provisional member (no 24/7 access yet)</p>
         <form action="<?php echo Utils::base(); ?>/?action=keyholder" method="post">
             <input type="hidden" name="id" value="<?php echo htmlspecialchars($person['id']); ?>" />
             <input type="hidden" name="access" value="BOTH" />
-            <?php if ($person['access'] === 'NO'): ?>
-                <button type="submit" class="btn btn-warning">Make keyholder</button>
-            <?php endif; ?>
+            <button type="submit" class="btn btn-warning">Make full member</button>
         </form>
 <?php
         break;


### PR DESCRIPTION
Fixes #29.

As decided on the mailing list, change from "keyholder"/"member" to "full member"/"provisional member" to reflect whether a member has 24/7 access.