### PR TITLE
Fixed request for exit button

### DIFF
--- a/arduino/DoorLock/pinmap.h
+++ b/arduino/DoorLock/pinmap.h
@@ -3,7 +3,7 @@
 
 //#define UPSTAIRS 1
 //#define DOWNSTAIRS 1
-//#define THIRD_DOOR 1
+#define THIRD_DOOR 1
 
 
 #include "ioexpander.h"
@@ -122,6 +122,8 @@
 #define REMOTE_IO_RST_PIN A2
 
 #define SENSE_PIN 8
+
+#define RELEASE_PIN A2
 
 #define EXTERNAL_EEPROM 1
 


### PR DESCRIPTION
Previous pin was set as A0 which on further inspection is used for software I2C. Now changed to A2 which is an unused analogue pin, which should be grounded to open the door. This is wired to the orange flying lead with a terminal block and a ground lead.